### PR TITLE
[DB] model 추가

### DIFF
--- a/src/models/HashTag.ts
+++ b/src/models/HashTag.ts
@@ -1,0 +1,72 @@
+import {
+  DataTypes,
+  Model,
+  Sequelize,
+  HasMany,
+  BelongsToMany,
+  BelongsToManyGetAssociationsMixin,
+} from 'sequelize'
+import { Post } from './Post'
+import { PostHashTagConnection } from './PostHashTagConnection'
+
+export class HashTag extends Model {
+  readonly id!: number
+  name!: string
+  postID!: string
+  createdAt!: Date
+  updatedAt!: Date
+  deletedAt?: Date
+
+  public static Post: BelongsToMany<HashTag, Post>
+  public static PostConnection: HasMany<HashTag, PostHashTagConnection>
+  public getPosts!: BelongsToManyGetAssociationsMixin<Post>
+}
+
+export function init(sequelize: Sequelize) {
+  return HashTag.init(
+    {
+      id: {
+        type: DataTypes.INTEGER,
+        primaryKey: true,
+        autoIncrement: true,
+      },
+      name: {
+        type: DataTypes.STRING,
+      },
+      postID: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+        field: 'post_id',
+      },
+      createdAt: {
+        type: DataTypes.DATE,
+        field: 'created_at',
+      },
+      updatedAt: {
+        type: DataTypes.DATE,
+        field: 'updated_at',
+      },
+    },
+    {
+      sequelize,
+      tableName: 'hashtag',
+      timestamps: true,
+      charset: 'utf8',
+      collate: 'utf8_unicode_ci',
+    },
+  )
+}
+
+export function associate() {
+  HashTag.Post = HashTag.belongsToMany(Post, {
+    as: 'posts',
+    through: PostHashTagConnection,
+    foreignKey: 'hashtag_id',
+    otherKey: 'post_id',
+  })
+
+  HashTag.PostConnection = HashTag.hasMany(PostHashTagConnection, {
+    as: 'postConnections',
+    foreignKey: 'hashtag_id',
+  })
+}

--- a/src/models/Post.ts
+++ b/src/models/Post.ts
@@ -1,11 +1,20 @@
-import { DataTypes, Model, Sequelize, BelongsTo, BelongsToGetAssociationMixin } from 'sequelize'
+import {
+  DataTypes,
+  Model,
+  Sequelize,
+  BelongsTo,
+  BelongsToGetAssociationMixin,
+  HasMany,
+  HasManyGetAssociationsMixin,
+} from 'sequelize'
 import { User } from './User'
+import { HashTag } from './HashTag'
+import { PostHashTagConnection } from './PostHashTagConnection'
 
 export class Post extends Model {
-  readonly id!: string
+  readonly id!: number
   authorID!: string
   url!: string
-  // hashtagID?: string
   likeCount?: number
   createdAt!: Date
   updatedAt!: Date
@@ -13,20 +22,20 @@ export class Post extends Model {
 
   public static Author: BelongsTo<Post, User>
   public getAuthor!: BelongsToGetAssociationMixin<User>
+
+  public static HashTag: HasMany<Post, HashTag>
+  public static HashTagConnection: HasMany<Post, PostHashTagConnection>
+  public getHashTags!: HasManyGetAssociationsMixin<HashTag>
 }
 
 export function init(sequelize: Sequelize) {
   return Post.init(
     {
       id: {
-        type: DataTypes.INTEGER, // google id is out of range in INT
+        type: DataTypes.INTEGER,
         primaryKey: true,
         autoIncrement: true,
       },
-      // hashtagID: {
-      //   type: DataTypes.INTEGER,
-      //   field: 'hashtag_id',
-      // },
       authorID: {
         type: DataTypes.STRING,
         allowNull: false,
@@ -69,5 +78,15 @@ export function associate() {
   Post.Author = Post.belongsTo(User, {
     as: 'author',
     foreignKey: 'author_id',
+  })
+  Post.HashTag = Post.belongsToMany(HashTag, {
+    as: 'hashtags',
+    through: PostHashTagConnection,
+    foreignKey: 'post_id',
+    otherKey: 'hashtag_id',
+  })
+  Post.HashTagConnection = Post.hasMany(PostHashTagConnection, {
+    as: 'hashtagConnections',
+    foreignKey: 'post_id',
   })
 }

--- a/src/models/Post.ts
+++ b/src/models/Post.ts
@@ -1,0 +1,73 @@
+import { DataTypes, Model, Sequelize, BelongsTo, BelongsToGetAssociationMixin } from 'sequelize'
+import { User } from './User'
+
+export class Post extends Model {
+  readonly id!: string
+  authorID!: string
+  url!: string
+  // hashtagID?: string
+  likeCount?: number
+  createdAt!: Date
+  updatedAt!: Date
+  deletedAt?: Date
+
+  public static Author: BelongsTo<Post, User>
+  public getAuthor!: BelongsToGetAssociationMixin<User>
+}
+
+export function init(sequelize: Sequelize) {
+  return Post.init(
+    {
+      id: {
+        type: DataTypes.INTEGER, // google id is out of range in INT
+        primaryKey: true,
+        autoIncrement: true,
+      },
+      // hashtagID: {
+      //   type: DataTypes.INTEGER,
+      //   field: 'hashtag_id',
+      // },
+      authorID: {
+        type: DataTypes.STRING,
+        allowNull: false,
+        field: 'author_id',
+      },
+      url: {
+        // https://stackoverflow.com/questions/29458445/what-is-a-safe-maximum-length-a-segment-in-a-url-path-should-be/33733386
+        type: DataTypes.TEXT,
+      },
+      likeCount: {
+        type: DataTypes.INTEGER,
+        defaultValue: 0,
+      },
+
+      createdAt: {
+        type: DataTypes.DATE,
+        field: 'created_at',
+      },
+      updatedAt: {
+        type: DataTypes.DATE,
+        field: 'updated_at',
+      },
+      deletedAt: {
+        type: DataTypes.DATE,
+        field: 'deleted_at',
+      },
+    },
+    {
+      sequelize,
+      tableName: 'post',
+      timestamps: true,
+      paranoid: true,
+      charset: 'utf8',
+      collate: 'utf8_unicode_ci',
+    },
+  )
+}
+
+export function associate() {
+  Post.Author = Post.belongsTo(User, {
+    as: 'author',
+    foreignKey: 'author_id',
+  })
+}

--- a/src/models/PostHashTagConnection.ts
+++ b/src/models/PostHashTagConnection.ts
@@ -1,0 +1,51 @@
+import { Sequelize, Model, DataTypes, BelongsTo } from 'sequelize'
+import { HashTag } from './HashTag'
+import { Post } from './Post'
+
+export class PostHashTagConnection extends Model {
+  public static Post: BelongsTo<PostHashTagConnection, Post>
+  public static HashTag: BelongsTo<PostHashTagConnection, HashTag>
+
+  public readonly id!: number
+  public postID!: number
+  public hashtagID!: number
+}
+
+export function init(sequelize: Sequelize) {
+  PostHashTagConnection.init(
+    {
+      id: {
+        type: DataTypes.INTEGER,
+        primaryKey: true,
+        autoIncrement: true,
+      },
+      postID: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+        field: 'post_id',
+      },
+      hashtagID: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+        field: 'hashtag_id',
+      },
+    },
+    {
+      sequelize,
+      tableName: 'post_hashtag_connection',
+      timestamps: false,
+    },
+  )
+}
+
+export function associate() {
+  PostHashTagConnection.Post = PostHashTagConnection.belongsTo(Post, {
+    as: 'post',
+    foreignKey: 'post_id',
+  })
+
+  PostHashTagConnection.HashTag = PostHashTagConnection.belongsTo(HashTag, {
+    as: 'hashtag',
+    foreignKey: 'hashtag_id',
+  })
+}

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -1,4 +1,5 @@
-import { DataTypes, Model, Sequelize } from 'sequelize'
+import { DataTypes, Model, Sequelize, HasMany, HasManyGetAssociationsMixin } from 'sequelize'
+import { Post } from './Post'
 
 export class User extends Model {
   readonly id!: string
@@ -7,6 +8,9 @@ export class User extends Model {
   createdAt!: Date
   updatedAt!: Date
   deletedAt?: Date
+
+  public static Posts: HasMany<User, Post>
+  public getPosts!: HasManyGetAssociationsMixin<Post>
 }
 
 export function init(sequelize: Sequelize) {
@@ -44,4 +48,11 @@ export function init(sequelize: Sequelize) {
       collate: 'utf8_unicode_ci',
     },
   )
+}
+
+export function associate() {
+  User.Posts = User.hasMany(Post, {
+    as: 'posts',
+    foreignKey: 'author_id',
+  })
 }

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -23,7 +23,9 @@ fs.readdirSync(__dirname)
   .forEach(file => {
     // @ts-ignore
     const model = require(path.join(__dirname, file)).init(sequelize)
-    db[model.name] = model
+    if (model) {
+      db[model?.name] = model
+    }
   })
 
 Object.keys(db).forEach(modelName => {


### PR DESCRIPTION
## description
1. table
- User: id, name, email 등 google oauth로 받아온 데이터 (name, email 등)
- Post: id, hashtag_id, author_id, like_count(like 테이블도 따로 만들어야겠네요), createdAt
  - title, description, preview image는 db에 저장 x. resolver에서 처리

2. association
- User - Post ->  1:N
- Post - HashTag ->  N:M 
  - (https://sequelize.org/master/class/lib/associations/belongs-to-many.js~BelongsToMany.html)
