### PR TITLE
[API] user - posts, consecutiveStudyDays 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "compression": "^1.7.4",
     "cookie-parser": "^1.4.5",
     "cors": "^2.8.5",
-    "date-fns": "^2.14.0",
     "dotenv": "^8.2.0",
     "express": "^4.17.1",
     "express-mysql-session": "^2.1.4",

--- a/schema/user.graphql
+++ b/schema/user.graphql
@@ -4,7 +4,7 @@ type User {
   email: String
   profileURL: String
   consecutiveStudyDays: [Date!]!
-  posts: [Post!]!
+  posts(orderBy: PostOrder, limit: Int): [Post!]! # orderBy: default { field: 'likeCount', direction: 'desc'}, limit: 10
   recommendations(limit: Int): [Post!]! # limit: default 10
   followers: [User!]!
   followings: [User!]!

--- a/yarn.lock
+++ b/yarn.lock
@@ -3392,11 +3392,6 @@ date-fns@^1.27.2:
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.30.1.tgz#2e71bf0b119153dbb4cc4e88d9ea5acfb50dc05c"
   integrity sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==
 
-date-fns@^2.14.0:
-  version "2.14.0"
-  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.14.0.tgz#359a87a265bb34ef2e38f93ecf63ac453f9bc7ba"
-  integrity sha512-1zD+68jhFgDIM0rF05rcwYO8cExdNqxjq4xP1QKM60Q45mnO6zaMWB4tOzrIr4M4GSLntsKeE4c9Bdl2jhL/yw==
-
 de-indent@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/de-indent/-/de-indent-1.0.2.tgz#b2038e846dc33baa5796128d0804b455b8c1e21d"


### PR DESCRIPTION
## description
- `posts`: orderBy, limit 파라미터 추가 (기본값은 좋아요 순, limit: 10)
- `consecutiveStudyDays`: 같은 날짜를 중복해서 갖고오는 오류 수정 